### PR TITLE
Fix #14

### DIFF
--- a/apollo/datasets/solar.py
+++ b/apollo/datasets/solar.py
@@ -259,7 +259,7 @@ class SolarDataset(TorchDataset):
         data = nam.open_range(start, stop, cache_dir=nam_cache)
 
         if feature_subset:
-            data = data[feature_subset]
+            data = data[list(feature_subset)]
 
         if geo_shape:
             data = slice_xy(data, center, geo_shape)


### PR DESCRIPTION
#14 was caused by indexing an xarray with a tuple.  Casting the tuple as a list before indexing xarray fixes the problem.

More info:
`xarray` checks if the key passed in `__getitem__` is a list of names by checking if the key is hashable.  Python tuples are hashable, but Python lists are not.  So when we pass a tuple of feature names as the index, `xarray` treats the *whole tuple* as a single key.