### PR TITLE
Fix url generation and missing argument

### DIFF
--- a/apollo/datasets/nam.py
+++ b/apollo/datasets/nam.py
@@ -526,7 +526,7 @@ class NamLoader:
             path = self.download(reftime, forecast)
             logger.info(f'reading {path}')
             ds = xr.open_dataset(path, engine='pynio')
-            ds = self._process_grib(reftime, forecast)
+            ds = self._process_grib(ds, reftime, forecast)
             datasets.append(ds)
         ds = xr.concat(datasets, dim='forecast')
 


### PR DESCRIPTION
Found a couple minor bugs in the nam loader.  This should fix them both.

Closes #32 