### PR TITLE
Predictor CLI Improvements

### DIFF
--- a/apollo/prediction/Predictor.py
+++ b/apollo/prediction/Predictor.py
@@ -15,13 +15,8 @@ from apollo import storage
 
 class Predictor(ABC):
 
-    @classmethod
     @abstractmethod
-    def get_name(cls):
-        pass
-
-    @abstractmethod
-    def __init__(self, target, target_hours):
+    def __init__(self, name, target, target_hours):
         """ Interface for predictors of solar radiation
 
         Args:
@@ -34,7 +29,8 @@ class Predictor(ABC):
         super().__init__()
         self.target_hours = target_hours
         self.target = target
-        self.filename = f'{self.get_name()}_{target_hours[0]}hr-{target_hours[-1]}hr_{target}.model'
+        self.name = name
+        self.filename = f'{name}_{target_hours[0]}hr-{target_hours[-1]}hr_{target}.model'
         self.models_dir = storage.get('trained_models')
 
     @abstractmethod
@@ -154,18 +150,18 @@ class Predictor(ABC):
         start_date, stop_date = prediction[0][0], prediction[-1][0]  # assumes the predictions are sorted
         start_date_f = Predictor._format_date(start_date)
         stop_date_f = Predictor._format_date(stop_date)
-        summary_filename = f'{self.get_name()}_{self.target}_{start_date_f}_to_{stop_date_f}.summary.json'
+        summary_filename = f'{self.name}_{self.target}_{start_date_f}_to_{stop_date_f}.summary.json'
         summary_path = os.path.join(summary_dir, summary_filename)
         summary_path = os.path.realpath(summary_path)
 
-        resource_filename = f'{self.get_name()}_{self.target}_{start_date_f}_to_{stop_date_f}.prediction.json'
+        resource_filename = f'{self.name}_{self.target}_{start_date_f}_to_{stop_date_f}.prediction.json'
         resource_path = os.path.join(output_dir, resource_filename)
         resource_path = os.path.realpath(resource_path)
 
         # contents of the summary file
         summary_dict = {
-            'source': self.get_name(),
-            'sourcelabel': self.get_name().replace('_', ' '),
+            'source': self.name,
+            'sourcelabel': self.name.replace('_', ' '),
             'site': self.target,
             'created': round(datetime.datetime.utcnow().timestamp())*1000,  # converted to ms
             'start': Predictor._datestring_to_posix(start_date),

--- a/apollo/prediction/SKPredictor.py
+++ b/apollo/prediction/SKPredictor.py
@@ -24,11 +24,7 @@ logger = logging.getLogger(__name__)
 
 class SKPredictor(Predictor):
 
-    @classmethod
-    def get_name(cls):
-        return 'skpredictor'
-
-    def __init__(self, estimator, parameter_grid, default_params, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
+    def __init__(self, name, estimator, parameter_grid, default_params, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
         """ Predictor that works with any scikit-learn estimator
 
         The `sklearn.multioutput.MultiOutputRegressor` API allows this predictor to make windowed predictions with any
@@ -57,7 +53,7 @@ class SKPredictor(Predictor):
             target_hours (Iterable[int]):
                 The future hours to be predicted.
         """
-        super().__init__(target=target, target_hours=target_hours)
+        super().__init__(name=name, target=target, target_hours=target_hours)
         self.regressor = MultiOutputRegressor(estimator=estimator, n_jobs=1)
         self.param_grid = parameter_grid
         self.default_params = default_params
@@ -163,12 +159,9 @@ class SKPredictor(Predictor):
 # define scikit predictors
 
 class LinearRegressionPredictor(SKPredictor):
-    @classmethod
-    def get_name(cls):
-        return 'linreg'
-
-    def __init__(self, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
+    def __init__(self, name='linreg', target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
         super().__init__(
+            name=name,
             estimator=LinearRegression(),
             parameter_grid=None,
             default_params=None,
@@ -177,12 +170,9 @@ class LinearRegressionPredictor(SKPredictor):
 
 
 class KNearestPredictor(SKPredictor):
-    @classmethod
-    def get_name(cls):
-        return 'knn'
-
-    def __init__(self, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
+    def __init__(self, name='knn', target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
         super().__init__(
+            name=name,
             estimator=KNeighborsRegressor(),
             parameter_grid={
                 'estimator__n_neighbors': np.arange(3, 15, 2),             # k
@@ -197,12 +187,9 @@ class KNearestPredictor(SKPredictor):
 
 
 class SupportVectorPredictor(SKPredictor):
-    @classmethod
-    def get_name(cls):
-        return 'svr'
-
-    def __init__(self, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
+    def __init__(self, name='svr', target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
         super().__init__(
+            name=name,
             estimator=SVR(),
             parameter_grid={
                 'estimator__C': np.arange(1.0, 1.6, 0.2),                  # penalty parameter C of the error term
@@ -221,12 +208,9 @@ class SupportVectorPredictor(SKPredictor):
 
 
 class DTreePredictor(SKPredictor):
-    @classmethod
-    def get_name(cls):
-        return 'dtree'
-
-    def __init__(self, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
+    def __init__(self, name='dtree', target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
         super().__init__(
+            name=name,
             estimator=DecisionTreeRegressor(),
             parameter_grid={
                 'estimator__splitter': ['best', 'random'],         # splitting criterion
@@ -243,12 +227,9 @@ class DTreePredictor(SKPredictor):
 
 
 class RandomForestPredictor(SKPredictor):
-    @classmethod
-    def get_name(cls):
-        return 'rf'
-
-    def __init__(self, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
+    def __init__(self, name='rf', target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
         super().__init__(
+            name=name,
             estimator=RandomForestRegressor(),
             parameter_grid={
                 'estimator__n_estimators': [10, 50, 100, 250],
@@ -265,12 +246,9 @@ class RandomForestPredictor(SKPredictor):
 
 
 class GradientBoostedPredictor(SKPredictor):
-    @classmethod
-    def get_name(cls):
-        return 'gbt'
-
-    def __init__(self, target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
+    def __init__(self, name='gbt', target='UGA-C-POA-1-IRR', target_hours=tuple(np.arange(1, 25))):
         super().__init__(
+            name=name,
             estimator=XGBRegressor(),
             parameter_grid={
                 'estimator__learning_rate': np.arange(0.03, 0.07, 0.02),   # learning rate


### PR DESCRIPTION
In response to our discussion today, I modified the `train` action to avoid parameter tuning by default.   Instead, hyperparameters default to reasonable values found empirically.

We were previously importing each scikit-learn estimator and storing its hyperparameter grid in the `apollo.prediction.__main__` file.  This has been changed such that each estimator now has its own class which inherits from `SKPredictor`.

I also noticed that the `predict` action was failing to download NAM forecasts if they hadn't already been cached.  This has been fixed.