### PR TITLE
Fix bug caused by misaligned target reftimes

### DIFF
--- a/apollo/datasets/solar.py
+++ b/apollo/datasets/solar.py
@@ -225,7 +225,6 @@ def load_targets(target, start, stop, target_hours):
         # See https://github.com/pydata/xarray/issues/1463
         # and https://github.com/cbarrick/apollo/issues/39
         x = target_data_raw[target].copy(deep=True)
-        # xarray's deep copy does not copy coordinates or attributes, so we do it manually
         for coord in x.coords:
             x.coords[coord].data = np.copy(x.coords[coord].data)
         x.attrs = deepcopy(x.attrs)


### PR DESCRIPTION
This should fix #39 by manually deep copying the coordinates of the DataArray for each lagged target hour.

Ideally, the line 
```python
x = target_data_raw[target].copy(deep=True)
```
would be sufficient, but it fails to deep copy the coordinates of the DataArray.  The discussion in #39 explains why this was a problem.