### PR TITLE
Fix typo in name of keyword argument

### DIFF
--- a/apollo/models/base.py
+++ b/apollo/models/base.py
@@ -109,7 +109,7 @@ def save(model):
 
     # Save the model under a directory with a matching name.
     path = root / model.name
-    path.mkdir(parents=True, exists_ok=True)
+    path.mkdir(parents=True, exist_ok=True)
     model.save(path)
 
 


### PR DESCRIPTION
`exists_ok` should be `exist_ok` [Docs](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir)

We fixed this in the `load` method during review of #41 but missed the same typo in the `save` method.