### PR TITLE
Remove hard dependency on PyTorch

### DIFF
--- a/apollo/datasets/solar.py
+++ b/apollo/datasets/solar.py
@@ -18,6 +18,7 @@ most useful for Scikit-Learn estimators and XGBoost which do not (and cannot)
 exploit the high dimension shape of the features.
 '''
 
+from copy import deepcopy
 from pathlib import Path
 
 import dask.array as da
@@ -26,10 +27,6 @@ import pandas as pd
 import scipy as sp
 import scipy.spatial
 import xarray as xr
-
-import torch
-from torch.utils.data import Dataset as TorchDataset
-from copy import deepcopy
 
 import apollo.storage
 from apollo.datasets import nam, ga_power
@@ -234,7 +231,7 @@ def load_targets(target, start, stop, target_hours):
     return target_data
 
 
-class SolarDataset(TorchDataset):
+class SolarDataset:
     '''A high level interface for the solar prediction dataset.
 
     This class unifies the NAM-NMM and GA Power datasets and provides many

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,6 @@ name: apollo
 
 channels:
     - conda-forge
-    - pytorch
-    - defaults
 
 dependencies:
     # Core stack
@@ -20,7 +18,6 @@ dependencies:
     - pynio
     - scikit-learn
     - xgboost
-    - pytorch
     - requests
 
     # Documentation


### PR DESCRIPTION
This also removes our dependency on the Anaconda default channel, which
may make dependency resolution more consistent.

This closes #44.