### PR TITLE
Improve formatting of validation results

### DIFF
--- a/apollo/bin/evaluate.py
+++ b/apollo/bin/evaluate.py
@@ -3,7 +3,6 @@ import pandas as pd
 from sklearn.metrics import mean_absolute_error as mae, \
     mean_squared_error as mse, r2_score as r2
 from sklearn.model_selection import TimeSeriesSplit
-import sys
 
 from apollo.models.base import list_trained_models
 from apollo.models.base import load as load_model


### PR DESCRIPTION
Previously, the `apollo.bin.evaluate` script would dump a Python dictionary to `stdout`, which has pretty ugly formatting.

This makes the output of the `evaluate` script a little nicer.  The user can choose to output results as a csv file, or they can have a nicely-formatted table printed to `stdout`.