### PR TITLE
Fix issue setting model hyperparams

### DIFF
--- a/apollo/models/linear.py
+++ b/apollo/models/linear.py
@@ -5,9 +5,13 @@ from apollo.models.scikit_estimator import ScikitModel
 
 
 class LinearRegression(ScikitModel):
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._estimator = scikit_LinearRegression()
+
     @property
     def estimator(self):
-        return scikit_LinearRegression()
+        return self._estimator
 
     @property
     def default_hyperparams(self):
@@ -15,9 +19,13 @@ class LinearRegression(ScikitModel):
 
 
 class SVR(ScikitModel):
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._estimator = scikit_SVR()
+
     @property
     def estimator(self):
-        return scikit_SVR()
+        return self._estimator
 
     @property
     def default_hyperparams(self):

--- a/apollo/models/neighbors.py
+++ b/apollo/models/neighbors.py
@@ -4,9 +4,13 @@ from apollo.models.scikit_estimator import ScikitModel
 
 
 class KNearest(ScikitModel):
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._estimator = KNeighborsRegressor()
+
     @property
     def estimator(self):
-        return KNeighborsRegressor()
+        return self._estimator
 
     @property
     def default_hyperparams(self):

--- a/apollo/models/trees.py
+++ b/apollo/models/trees.py
@@ -6,9 +6,13 @@ from apollo.models.scikit_estimator import ScikitModel
 
 
 class DecisionTree(ScikitModel):
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._estimator = DecisionTreeRegressor()
+
     @property
     def estimator(self):
-        return DecisionTreeRegressor()
+        return self._estimator
 
     @property
     def default_hyperparams(self):
@@ -20,9 +24,13 @@ class DecisionTree(ScikitModel):
 
 
 class RandomForest(ScikitModel):
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._estimator = RandomForestRegressor()
+
     @property
     def estimator(self):
-        return RandomForestRegressor()
+        return self._estimator
 
     @property
     def default_hyperparams(self):
@@ -34,14 +42,18 @@ class RandomForest(ScikitModel):
 
 
 class GradientBoostedTrees(ScikitModel):
+    def __init__(self, name=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._estimator = XGBRegressor()
+
     @property
     def estimator(self):
-        return XGBRegressor()
+        return self._estimator
 
     @property
     def default_hyperparams(self):
         return {
             'learning_rate': 0.05,
             'n_estimators': 200,
-            'max_depth': 5,
+            'max_depth': 20,
         }


### PR DESCRIPTION
I found the bug causing #72 .  It came from these two lines in the train method of `ScikitModel`:
```python
. . .
        self.estimator.set_params(**self.model_kwargs)
        model = MultiOutputRegressor(estimator=self.estimator, n_jobs=1)
. . .
```
This treats `self.estimator` as a singleton, but in reality a new estimator was being created every time the `estimator` property was being accessed.  For example:
```python
. . .
class DecisionTree(ScikitModel):
    @property
    def estimator(self):
        return DecisionTreeRegressor()
. . .
```

This PR fixes #72 by making the estimator property behave like a singleton, which is probably how it should have been all along.
