### PR TITLE
Set the UTC timezone on all timestamps

### DIFF
--- a/apollo/bin/data_check.py
+++ b/apollo/bin/data_check.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
-import apollo.storage
+from apollo import storage, timestamps
 from apollo.datasets import nam
 
 
@@ -19,10 +19,10 @@ def reftimes(args):
 
     step = pd.Timedelta(6, 'h')
 
-    stop = pd.Timestamp(args.reftime).floor('6h')
+    stop = timestamps.utc_timestamp(args.reftime).floor('6h')
 
     if args.start:
-        start = pd.Timestamp(args.start).floor('6h')
+        start = timestamps.utc_timestamp(args.start).floor('6h')
     elif args.count:
         start = stop - (args.count - 1) * step
     else:
@@ -96,13 +96,13 @@ if __name__ == '__main__':
         logging.debug(f'  {arg}: {val}')
 
     if args.store:
-        apollo.storage.set_root(args.store)
+        storage.set_root(args.store)
 
-    now = pd.Timestamp('now', tz='utc')
+    now = timestamps.utc_timestamp('now', tz='utc')
 
     for (a, b) in dataset_pairs(args):
-        time_a = pd.Timestamp(a.reftime.data[0]).floor('6h')
-        time_b = pd.Timestamp(b.reftime.data[0]).floor('6h')
+        time_a = timestamps.utc_timestamp(a.reftime.data[0]).floor('6h')
+        time_b = timestamps.utc_timestamp(b.reftime.data[0]).floor('6h')
         vars_a = set(a.variables.keys())
         vars_b = set(b.variables.keys())
         path_a = nc_path(time_a)

--- a/apollo/bin/download.py
+++ b/apollo/bin/download.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pandas as pd
 
-import apollo.storage
+from apollo import storage, timestamps
 from apollo.datasets import nam
 
 
@@ -60,12 +60,12 @@ if __name__ == '__main__':
         logging.debug(f'  {arg}: {val}')
 
     if args.dest:
-        apollo.storage.set_root(args.dest)
+        storage.set_root(args.dest)
 
     step = pd.Timedelta(6, 'h')
-    stop = pd.Timestamp(args.reftime).floor('6h')
+    stop = timestamps.utc_timestamp(args.reftime).floor('6h')
     if args.start:
-        start = pd.Timestamp(args.start).floor('6h')
+        start = timestamps.utc_timestamp(args.start).floor('6h')
     elif args.count:
         start = stop - (args.count - 1) * step
     else:

--- a/apollo/bin/evaluate.py
+++ b/apollo/bin/evaluate.py
@@ -4,9 +4,9 @@ from sklearn.metrics import mean_absolute_error as mae, \
     mean_squared_error as mse, r2_score as r2
 from sklearn.model_selection import TimeSeriesSplit
 
+from apollo import models, timestamps
 from apollo.models.base import list_trained_models
 from apollo.models.base import load as load_model
-from apollo.models import *
 
 
 # define custom RMSE metric

--- a/apollo/bin/predict.py
+++ b/apollo/bin/predict.py
@@ -1,8 +1,7 @@
 import argparse
-import pandas as pd
 import numbers
 
-import apollo.models  # makes all model classes discoverable
+from apollo import models, timestamps
 from apollo.models.base import list_trained_models
 from apollo.models.base import load as load_model
 from apollo.output import write_csv, write_json
@@ -41,9 +40,9 @@ def main():
     args = parser.parse_args()
     args = vars(args)
 
-    reftime = pd.Timestamp(args['reftime'])
+    reftime = timestamps.utc_timestamp(args['reftime'])
     if 'latest' in args:
-        reftime = pd.Timestamp('now').floor('6h')
+        reftime = timestamps.utc_timestamp('now').floor('6h')
     formatted_reftime = reftime.strftime('%Y_%m_%d-%H:%M')
 
     print('Generating predictions...')

--- a/apollo/datasets/ga_power.py
+++ b/apollo/datasets/ga_power.py
@@ -13,7 +13,7 @@ import pandas as pd
 import xarray as xr
 import sqlite3
 
-import apollo.storage
+from apollo import storage, timestamps
 
 
 # Module level logger
@@ -116,7 +116,7 @@ def open_mb007(*cols, group=2017):
             The dataset giving the targets.
     '''
     # The data directory contains more than just the mb-007 labels.
-    data_dir = apollo.storage.get('GA-POWER')
+    data_dir = storage.get('GA-POWER')
     path = data_dir / f'mb-007.{group}.log'
 
     # Ensure reftime is always selected and is a list.
@@ -163,11 +163,11 @@ def open_sqlite(*cols, start, stop):
     Returns:
 
     '''
-    data_dir = apollo.storage.get('GA-POWER')
+    data_dir = storage.get('GA-POWER')
     path = data_dir / 'solar_farm.sqlite'
     connection = sqlite3.connect(str(path))
 
-    start, stop = pd.Timestamp(start), pd.Timestamp(stop)
+    start, stop = timestamps.utc_timestamp(start), timestamps.utc_timestamp(stop)
 
     # convert start and stop timestamps to unix epoch in seconds
     unix_start = start.value // 10**9

--- a/apollo/datasets/nam.py
+++ b/apollo/datasets/nam.py
@@ -42,7 +42,7 @@ import pandas as pd
 import requests
 import xarray as xr
 
-from apollo import storage
+from apollo import storage, timestamps
 
 
 # Module level logger
@@ -216,8 +216,8 @@ class NamLoader:
             str:
                 A URL to a GRIB file.
         '''
-        reftime = pd.Timestamp(reftime).floor('6h')
-        now = pd.Timestamp('now').floor('6h')
+        reftime = timestamps.utc_timestamp(reftime).floor('6h')
+        now = timestamps.utc_timestamp('now').floor('6h')
         delta = now - reftime
         if pd.Timedelta(7, 'd') < delta:
             url_fmt = ARCHIVE_URL
@@ -238,7 +238,7 @@ class NamLoader:
             pathlib.Path:
                 The local path for a GRIB file, which may not exist.
         '''
-        reftime = pd.Timestamp(reftime).floor('6h')
+        reftime = timestamps.utc_timestamp(reftime).floor('6h')
         prefix_fmt = 'nam.{ref.year:04d}{ref.month:02d}{ref.day:02d}'
         filename_fmt = 'nam.t{ref.hour:02d}z.awphys{forecast:02d}.tm00.grib'
         prefix = prefix_fmt.format(forecast=forecast, ref=reftime)
@@ -256,7 +256,7 @@ class NamLoader:
             pathlib.Path:
                 The local path to a netCDF file, which may not exist.
         '''
-        reftime = reftime = pd.Timestamp(reftime).floor('6h')
+        reftime = reftime = timestamps.utc_timestamp(reftime).floor('6h')
         prefix = f'nam.{reftime.year:04d}{reftime.month:02d}{reftime.day:02d}'
         filename = f'nam.t{reftime.hour:02d}z.awphys.tm00.nc'
         return self.data_dir / prefix / filename
@@ -403,8 +403,8 @@ class NamLoader:
         # Both are stored as integers with appropriate units.
         # The reftime dimension is hours since the Unix epoch (1970-01-01 00:00).
         # The forecast dimension is hours since the reftime.
-        reftime = pd.Timestamp(reftime).floor('6h')
-        epoch = pd.Timestamp('1970-01-01 00:00')
+        reftime = timestamps.utc_timestamp(reftime).floor('6h')
+        epoch = timestamps.utc_timestamp('1970-01-01 00:00')
         delta_seconds = int((reftime - epoch).total_seconds())
         delta_hours = delta_seconds // 60 // 60
         ds = ds.assign_coords(
@@ -500,7 +500,7 @@ class NamLoader:
         for v in metadata:
             ds[v] = ds[v].assign_attrs(metadata[v])
 
-        now = pd.Timestamp("now", tz='utc')
+        now = timestamps.utc_timestamp("now", tz='utc')
         ds.attrs['title'] = 'NAM-UGA, a subset of NAM-NMM for solar forecasting research in Georgia'
         ds.attrs['history'] = f'{now.isoformat()} Initial conversion from GRIB files released by NCEP\n'
 
@@ -615,8 +615,8 @@ class NamLoader:
                 A single dataset containing all forecasts at the given reference
                 times. Some data may be dropped when combining forecasts.
         '''
-        start = pd.Timestamp(start).floor('6h')
-        stop = pd.Timestamp(stop).floor('6h')
+        start = timestamps.utc_timestamp(start).floor('6h')
+        stop = timestamps.utc_timestamp(stop).floor('6h')
 
         datasets = []
         delta = pd.Timedelta(6, 'h')

--- a/apollo/datasets/solar.py
+++ b/apollo/datasets/solar.py
@@ -28,7 +28,7 @@ import scipy as sp
 import scipy.spatial
 import xarray as xr
 
-import apollo.storage
+from apollo import timestamps
 from apollo.datasets import nam, ga_power
 
 
@@ -313,8 +313,8 @@ class SolarDataset:
         '''
         assert 0 <= lag
 
-        start = pd.Timestamp(start) - pd.Timedelta(6, 'h') * lag
-        stop = pd.Timestamp(stop)
+        start = timestamps.utc_timestamp(start) - pd.Timedelta(6, 'h') * lag
+        stop = timestamps.utc_timestamp(stop)
         data = nam.open_range(start, stop)
 
         if feature_subset:

--- a/apollo/models/base.py
+++ b/apollo/models/base.py
@@ -7,10 +7,9 @@ import shutil
 from sklearn.model_selection import TimeSeriesSplit
 from sklearn.metrics import mean_absolute_error
 
-from apollo import storage
-import apollo.datasets.ga_power as ga_power
+from apollo import modela, storage, timestamps
+from apollo.datasets import ga_power
 from apollo.datasets.nam import CacheMiss
-import apollo.models  # makes model subclasses discoverable
 
 
 logger = logging.getLogger(__name__)
@@ -140,8 +139,8 @@ class Model(abc.ABC):
 
         '''
         # find all reftimes in the testing set
-        first = pd.Timestamp(first).floor(freq='6h')
-        last = pd.Timestamp(last).floor(freq='6h')
+        first = timestamps.utc_timestamp(first).floor(freq='6h')
+        last = timestamps.utc_timestamp(last).floor(freq='6h')
         reftimes = pd.date_range(first, last, freq='6h')
 
         max_target_hour = max(self.target_hours)

--- a/apollo/models/persistence.py
+++ b/apollo/models/persistence.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pathlib
 import pickle
 
+from apollo import timestamps
 from apollo.datasets.ga_power import open_sqlite
 from apollo.datasets.solar import DEFAULT_TARGET, DEFAULT_TARGET_HOURS
 from apollo.models.base import Model
@@ -19,7 +20,7 @@ class PersistenceModel(Model):
             **kwargs:
                 The keyword arguments forwarded to the data loader
         '''
-        ts = pd.Timestamp('now')
+        ts = timestamps.utc_timestamp('now')
 
         self.kwargs = kwargs
         self.data_args = kwargs
@@ -67,7 +68,7 @@ class PersistenceModel(Model):
         pass
 
     def forecast(self, reftime):
-        reftime = pd.Timestamp(reftime)
+        reftime = timestamps.utc_timestamp(reftime)
         forecast_reach = max(*self.target_hours)  # maximum forecast hour
         past_values_start = reftime - pd.Timedelta(forecast_reach, 'h')
         past_values_end = reftime

--- a/apollo/models/scikit_estimator.py
+++ b/apollo/models/scikit_estimator.py
@@ -7,6 +7,7 @@ import pickle
 from sklearn.externals import joblib
 from sklearn.multioutput import MultiOutputRegressor
 
+from apollo import timestamps
 from apollo.datasets.solar import SolarDataset, \
     DEFAULT_TARGET, DEFAULT_TARGET_HOURS
 from apollo.models.base import Model
@@ -25,7 +26,7 @@ class ScikitModel(Model, abc.ABC):
                 Keyword arguments used to customize data loading and the
                 hyperparameters of the underlying scikit-learn estimator.
         '''
-        ts = pd.Timestamp('now')
+        ts = timestamps.utc_timestamp('now')
         self.kwargs = kwargs
 
         # peel off kwargs corresponding to model hyperparams
@@ -120,7 +121,7 @@ class ScikitModel(Model, abc.ABC):
         data_args = dict(self.data_args)
         data_args['target'] = None
 
-        reftime = pd.Timestamp(reftime)
+        reftime = timestamps.utc_timestamp(reftime)
 
         ds = SolarDataset(reftime, reftime + pd.Timedelta(6, 'h'), **data_args)
         x = np.asarray(ds.tabular())

--- a/apollo/output.py
+++ b/apollo/output.py
@@ -1,19 +1,18 @@
 import json
-import pandas as pd
 import pathlib
 import numpy as np
 
-import apollo.storage as storage
+from apollo import storage, timestamps
 from apollo.datasets.solar import ATHENS_LATLON
 
 
 def _datestring_to_posix(date_string):
-    timestring = pd.to_datetime(date_string, utc=True).timestamp()
+    timestring = timestamps.utc_timestamp(date_string).timestamp()
     return int(timestring * 1000)  # convert to milliseconds
 
 
 def _format_date(date_string):
-    dt = pd.to_datetime(date_string, utc=True)
+    dt = timestamps.utc_timestamp(date_string)
     return dt.strftime('%Y-%m-%dT%X')
 
 
@@ -94,7 +93,7 @@ def write_json(forecast, reftime, source, name, description,
         'targets': ','.join(forecast.columns),
         'location': location,
         'created': _datestring_to_posix('now'),
-        'reftime': _datestring_to_posix(pd.Timestamp(reftime)),
+        'reftime': _datestring_to_posix(timestamps.utc_timestamp(reftime)),
         'start': _datestring_to_posix(forecast.first_valid_index()),
         'stop': _datestring_to_posix(forecast.last_valid_index()),
         'columns': columns,

--- a/apollo/timestamps.py
+++ b/apollo/timestamps.py
@@ -1,0 +1,52 @@
+'''Utilities for working with Timestamps.
+'''
+
+import time
+
+import pandas as pd
+
+
+def utc_timestamp(*args, **kwargs):
+    '''Construct a UTC timestamp.
+
+    This is equivalent to the constructor for :class:`pandas.Timestamp` except
+    that the returned timestamp is always timezone-aware and set to UTC. This
+    function implements the following conventions:
+
+    - Explicit timestamps without timezones are localized to UTC.
+    - Explicit timestamps with timezones are converted to UTC.
+    - Implicit timestamps refer to the current time in UTC. This is equivalent
+      to localizing to the current timezone then converting to UTC.
+
+    Arguments:
+        *args: Forwarded to :class:`pandas.Timestamp`.
+        **kwargs: Forwarded to :class:`pandas.Timestamp`.
+
+    Returns:
+        pandas.Timestamp:
+            A timestamp set to the UTC timezone.
+    '''
+    if 'ts_input' in kwargs:
+        ts_input = kwargs['ts_input']
+    elif len(args) != 0:
+        ts_input = args[0]
+    else:
+        ts_input = None
+
+    ts = Timestamp(*args, **kwargs)
+
+    # - When the timestamp is tz-aware, we convert it to UTC.
+    # - When the timestamp is tz-naive but explict, we localize it to UTC.
+    # - When the timestamp is tz-naive and 'now' or 'today', we localize it to
+    #   the system timezone then convert it to UTC.
+    if ts.tz is None:
+        if ts_input == 'now' or ts_input == 'today':
+            localtz = time.localtime().tm_gmtoff
+            ts = ts.tz_localize(localtz)
+            ts = ts.tz_convert('UTC')
+        else:
+            ts = ts.tz_localize('UTC')
+    else:
+        ts = ts.tz_convert('UTC')
+
+    return ts

--- a/apollo/viz.py
+++ b/apollo/viz.py
@@ -14,6 +14,8 @@ import matplotlib.pyplot as plt
 
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
+from apollo import timestamps
+
 
 DAYS = np.array(['Sun.', 'Mon.', 'Tues.', 'Wed.', 'Thurs.', 'Fri.', 'Sat.'])
 MONTHS = np.array(['Jan.', 'Feb.', 'Mar.', 'Apr.', 'May', 'June',
@@ -287,7 +289,7 @@ def nam_map(xrds, feature, reftime=0, forecast=0, level=0, title=None,
 
     # Set the title.
     if title is None:
-        reftime_iso = pd.Timestamp(data.reftime.data).isoformat()
+        reftime_iso = timestamps.utc_timestamp(data.reftime.data).isoformat()
         plt.title(f'{reftime_iso}Z + {forecast} hours')
     else:
         plt.title(title)


### PR DESCRIPTION
This was accomplished with the following command:

    sed -i "s/Timestamp\(([^\)]+)\)/Timestamp(\1, tz='utc')/g" apollo/**/*.py

There were two occurrences where the timezone was already being set.
Those were corrected by hand after the `sed` command.

Fixes #75.