### PR TITLE
Separate downloading and loading logic for the NAM dataset

### DIFF
--- a/apollo/bin/check.py
+++ b/apollo/bin/check.py
@@ -55,7 +55,7 @@ def local_reftimes(args):
     '''
     for reftime in reftimes(args):
         try:
-            nam.open_local(reftime)
+            nam.open(reftime)
         except nam.CacheMiss:
             continue
         yield reftime
@@ -70,10 +70,10 @@ def dataset_pairs(args):
     while True:
         try:
             b = next(it)
-            data_a, data_b = nam.open_local(a), nam.open_local(b)
+            data_a, data_b = nam.open(a), nam.open(b)
             yield data_a, data_b
             data_a.close(); data_b.close()
-            data_a, data_b = nam.open_local(a), nam.open_local(b)
+            data_a, data_b = nam.open(a), nam.open(b)
             yield data_b, data_a
             a = b
         except StopIteration:

--- a/apollo/bin/download.py
+++ b/apollo/bin/download.py
@@ -129,14 +129,10 @@ def main(argv=None):
 
     for reftime in reftimes(args):
         try:
-            nam.open(
-                reftime,
-                fail_fast=args.fail_fast,
-                keep_gribs=args.keep_gribs,
-            )
+            nam.download(reftime, fail_fast=args.fail_fast, keep_gribs=args.keep_gribs)
         except Exception as e:
             logging.error(e)
-            logging.error(f'Could not load data for {reftime}')
+            logging.error(f'Could not download data for {reftime}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This refactors the way the NAM loader handles forecast loading and downloading.

Previously, there were three methods: `open`, `open_local`, and `open_range`.

- `open` took a list of reftimes and loaded a dataset, downloading missing forecasts.
- `open_local` was like `open` but threw a `CacheMiss` for missing forecasts.
- `open_range` took endpoints for a datetime range and loaded forecasts on that range, ignoring missing data.

This has been refactored into two methods: `open` and `open_range`.

- `open` takes a list of reftimes and loads them.
- `open_range` delegates to `open` to open forecasts on a datetime range.

The behavior on cache miss is now unified behind an argument `on_miss` to both functions. It takes a string with one of three values:

- `'raise'`: Raise a `CacheMiss` exception.
- `'download'`: Attempt to download the missing forecast.
- `'skip'`: Skip missing forecasts.

The default behavior for `open_range` is `'skip'` which is backwards compatible. The default behavior for `open` is now `'raise'` which is NOT backwards compatible. The CLI has been updated. This may effect other users of `NAMLoader` and `SolarDataset`.

The download-process-write loop is now in a method called `download`. The old `download` method is now called `_download_grib`.