### PR TITLE
Fix misspelled import

### DIFF
--- a/apollo/models/base.py
+++ b/apollo/models/base.py
@@ -7,7 +7,7 @@ import shutil
 from sklearn.model_selection import TimeSeriesSplit
 from sklearn.metrics import mean_absolute_error
 
-from apollo import models, storage, timestamps
+from apollo import storage, timestamps
 from apollo.datasets import ga_power
 from apollo.datasets.nam import CacheMiss
 


### PR DESCRIPTION
There was typo at the top of `apollo.models.base`

```python
from apollo import modela, storage, timestamps
```

I'm guessing the import statement was copy-pasted from somewhere else;  I don't think there's any reason to import `apollo.models` in `base.py`.
This PR fixes the bad import.