### PR TITLE
Remove explicit dask dependencies and conda-forge requirement

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,5 @@
 name: apollo
 
-channels:
-    - conda-forge
-
 dependencies:
     # Core stack
     - python>=3.6
@@ -11,8 +8,6 @@ dependencies:
     - matplotlib
     - cartopy
     - pandas
-    - dask
-    - dask-ml
     - xarray>=0.10
     - netcdf4
     - pynio


### PR DESCRIPTION
I made some tweaks to the environment file.

This patch removes the hard dask dependencies. Removing `dask-ml` enables us to switch from conda-forge to the Anaconda default channel.