### PR TITLE
Update default SVM params

### DIFF
--- a/apollo/models/linear.py
+++ b/apollo/models/linear.py
@@ -30,8 +30,8 @@ class SVR(ScikitModel):
     @property
     def default_hyperparams(self):
         return {
-            'C': 1000,
+            'C': 1200,
             'epsilon': 2,
             'kernel': 'rbf',
-            'gamma': 0.0001
+            'gamma': 9e-05
         }


### PR DESCRIPTION
The exceedingly poor performance of the Apollo SVMs was recently pointed out.

I ran a fresh hyperparameter search, and it found parameters that were *way* different than the Apollo defaults.  I think we were accidentally using hyperparameters optimized for the `sigmoid` or `linear` kernel rather than the `rbf` kernel.  Whoops.

This PR updates the default params to improve the default performance of the SVM model.  This isn't quite ready to merge - I have a second, finer-grained grid search running now, and I'll make another update to the params in response.