### PR TITLE
Fix typo in `train` script

### DIFF
--- a/apollo/bin/train.py
+++ b/apollo/bin/train.py
@@ -24,7 +24,7 @@ def main(argv=None):
         type=str,
         action='append',
         default=[],
-        dest='kwrags',  # Note that this is parsed into ``args.kwargs``.
+        dest='kwargs',  # Note that this is parsed into ``args.kwargs``.
         help='set a hyper-parameter for the model, may be specified multiple times',
     )
 


### PR DESCRIPTION
This fixes a trivial typo that broke the training script.  `kwrags` -> `kwargs`.

Didn't catch this when I was testing #84 