### PR TITLE
Remove additional spaces for dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,13 +21,13 @@ dependencies:
   - pvlib-python
   - siphon
 
-    # Data Explorer
-    - flask
-    - waitress
+  # Data Explorer
+  - flask
+  - waitress
 
-    # Documentation
-    - sphinx
-    - sphinx_rtd_theme
+  # Documentation
+  - sphinx
+  - sphinx_rtd_theme
 
   # Dev tooling
   - ipython


### PR DESCRIPTION
Remove additional spaces in `Data Explorer` and `Documentation` dependencies, which was creating an error while creating `apollo` conda environment.